### PR TITLE
update to eh v1.0.0 and make defmt optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ exclude = [
 ]
 
 [dependencies]
-defmt = "0.3.2"
-embedded-hal-async = "0.1.0-alpha.1"
-panic-rtt-core = {version="0.1.0", optional=true}
+defmt = { version = "0.3.2", optional = true }
+embedded-hal-async = "1.0.0"
+panic-rtt-core = { version = "0.2.1", optional = true }
 
 [features]
 default = []
-rttdebug = ["panic-rtt-core"]
-
+rttdebug = ["dep:panic-rtt-core"]
+defmt = ["dep:defmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmc5883-async"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Todd Stellanova <tstellanova@users.noreply.github.com>","Aïssata Maiga <aimaiga2@gmail.com>", "Henrik Alsér <henrik.alser@me.com>"]
 edition = "2018"
 description = "HMC5883 magnetometer async driver for embedded hal"


### PR DESCRIPTION
Updates the crate to embedded-hal v1.0.0, and also make defmt an optional dependency for those who use the "log" crate